### PR TITLE
Update Products Without Sales(solution-1,2).txt

### DIFF
--- a/Products Without Sales(solution-1,2).txt
+++ b/Products Without Sales(solution-1,2).txt
@@ -1,24 +1,8 @@
----- Products Without Sales(solution_1)
-
-
-SELECT 
-     product.sku, product.product_name
-FROM 
-     product
-WHERE
-     product.id NOT IN (SELECT product_id FROM invoice_item);
-
-
-
------ Products Without Sales(solution_2)
-
 SELECT 
      product.sku, product.product_name
 FROM 
      product
 WHERE 
      product.id NOT IN (SELECT product_id FROM invoice_item)
-GROUP BY
-      1,2
 ORDER BY
-      product.sku ASC;
+     product.sku ASC;


### PR DESCRIPTION
The GROUP BY in Solution 2 is unnecessary because no aggregate functions are used, and duplicates are unlikely if product.sku and product.product_name are unique. It adds redundant processing, slowing down the query without altering results. Removing it simplifies and optimizes the query: